### PR TITLE
SELIC rate added in API request

### DIFF
--- a/src/benchmarks/benchmarks.ts
+++ b/src/benchmarks/benchmarks.ts
@@ -10,7 +10,23 @@ const getBenchmark = async (
    * CÓDIGO 12: CDI
    * CÓDIGO 7832: BOVESPA
    * */
-  const codeBenchmark = benchmark === 'CDI' ? 12 : 7832;
+  let codeBenchmark;
+
+  switch(benchmark) {
+
+    case 'CDI':
+      codeBenchmark = 12;
+      break;
+      
+    case 'BOVESPA':
+      codeBenchmark = 7832;
+      break;
+      
+      case 'SELIC':
+      codeBenchmark = 11;
+      break;
+  }
+
   const bechmarkRequest = await axios.get<{ data: string; valor: string }[]>(
     `https://api.bcb.gov.br/dados/serie/bcdata.sgs.${codeBenchmark}/dados`,
     {


### PR DESCRIPTION
# SELIC rate added in API request

The selic rate was added for testing purposes through the REST API request in the backend
Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update